### PR TITLE
fix(evm): export genesis properly

### DIFF
--- a/cosmos/x/evm/plugins/state/genesis.go
+++ b/cosmos/x/evm/plugins/state/genesis.go
@@ -103,6 +103,9 @@ func (p *plugin) ExportGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 		}
 		account.Code = p.GetCode(address)
 		account.Nonce = p.GetNonce(address)
+		if account.Balance == nil {
+			account.Balance = big.NewInt(0)
+		}
 		ethGen.Alloc[address] = account
 
 		return false

--- a/cosmos/x/evm/plugins/state/genesis.go
+++ b/cosmos/x/evm/plugins/state/genesis.go
@@ -48,6 +48,9 @@ func (p *plugin) InitGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 				p.SetState(address, k, v)
 			}
 		}
+		if account.Nonce != 0 {
+			p.SetNonce(address, account.Nonce)
+		}
 	}
 	p.Finalize()
 }
@@ -85,6 +88,18 @@ func (p *plugin) ExportGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 
 		account.Code = p.GetCode(address)
 		account.Balance = p.GetBalance(address)
+		ethGen.Alloc[address] = account
+
+		return false
+	})
+
+	// Iterate Code and set the genesis accounts.
+	p.IterateCode(func(address common.Address, codeHash common.Hash) bool {
+		account, ok := ethGen.Alloc[address]
+		if !ok {
+			account = core.GenesisAccount{}
+		}
+		account.Code = p.GetCode(address)
 		ethGen.Alloc[address] = account
 
 		return false

--- a/cosmos/x/evm/plugins/state/genesis.go
+++ b/cosmos/x/evm/plugins/state/genesis.go
@@ -71,6 +71,7 @@ func (p *plugin) ExportGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 			account.Storage = make(map[common.Hash]common.Hash)
 		}
 		account.Balance = p.GetBalance(address)
+		account.Nonce = p.GetNonce(address)
 		ethGen.Alloc[address] = account
 		return false
 	})
@@ -88,6 +89,7 @@ func (p *plugin) ExportGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 
 		account.Code = p.GetCode(address)
 		account.Balance = p.GetBalance(address)
+		account.Nonce = p.GetNonce(address)
 		ethGen.Alloc[address] = account
 
 		return false
@@ -100,6 +102,7 @@ func (p *plugin) ExportGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 			account = core.GenesisAccount{}
 		}
 		account.Code = p.GetCode(address)
+		account.Nonce = p.GetNonce(address)
 		ethGen.Alloc[address] = account
 
 		return false

--- a/cosmos/x/evm/plugins/state/plugin.go
+++ b/cosmos/x/evm/plugins/state/plugin.go
@@ -363,6 +363,27 @@ func (p *plugin) SetCode(addr common.Address, code []byte) {
 	}
 }
 
+// IterateCode iterates over all the contract code, and calls the given function.
+func (p *plugin) IterateCode(fn func(addr common.Address, value common.Hash) bool) {
+	it := storetypes.KVStorePrefixIterator(
+		p.cms.GetKVStore(p.storeKey),
+		[]byte{types.CodeHashKeyPrefix},
+	)
+	defer func() {
+		if err := it.Close(); err != nil {
+			p.savedErr = err
+		}
+	}()
+
+	for ; it.Valid(); it.Next() {
+		k := it.Key()
+		addr := AddressFromCodeHashKey(k)
+		if fn(addr, p.GetCodeHash(addr)) {
+			break
+		}
+	}
+}
+
 // =============================================================================
 // Storage
 // =============================================================================


### PR DESCRIPTION
To get contract info in genesis.json which has only code field