### PR TITLE
feat: integrate evm balance and cosmos bank (mito <-> umito integration)

### DIFF
--- a/cosmos/x/evm/depinject.go
+++ b/cosmos/x/evm/depinject.go
@@ -51,6 +51,7 @@ type DepInjectInput struct {
 	CustomPrecompiles func() *ethprecompile.Injector `optional:"true"`
 
 	AccountKeeper AccountKeeper
+	BankKeeper    BankKeeper
 	StakingKeeper StakingKeeper
 }
 
@@ -71,6 +72,7 @@ func ProvideModule(in DepInjectInput) DepInjectOutput {
 
 	k := keeper.NewKeeper(
 		in.AccountKeeper,
+		in.BankKeeper,
 		in.StakingKeeper,
 		in.Key,
 		in.Mempool,

--- a/cosmos/x/evm/interfaces.go
+++ b/cosmos/x/evm/interfaces.go
@@ -51,7 +51,6 @@ type BankKeeper interface {
 		senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
-	SendCoins(ctx context.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 }
 
 type StakingKeeper interface {

--- a/cosmos/x/evm/keeper/host.go
+++ b/cosmos/x/evm/keeper/host.go
@@ -53,6 +53,7 @@ type Host interface {
 		storetypes.StoreKey,
 		storetypes.StoreKey,
 		state.AccountKeeper,
+		state.BankKeeper,
 		func(height int64, prove bool) (sdk.Context, error),
 	)
 }
@@ -96,10 +97,11 @@ func (h *host) Setup(
 	storeKey storetypes.StoreKey,
 	_ storetypes.StoreKey,
 	ak state.AccountKeeper,
+	bk state.BankKeeper,
 	qc func(height int64, prove bool) (sdk.Context, error),
 ) {
 	// Setup the state, precompile, historical, and txpool plugins
-	h.sp = state.NewPlugin(ak, storeKey, log.NewFactory(h.pcs().GetPrecompiles()))
+	h.sp = state.NewPlugin(ak, bk, storeKey, log.NewFactory(h.pcs().GetPrecompiles()))
 	h.pp = precompile.NewPlugin(h.pcs().GetPrecompiles(), h.sp)
 	// TODO: re-enable historical plugin using ABCI listener.
 	h.hp = historical.NewPlugin(h.cp, h.bp, nil, storeKey)

--- a/cosmos/x/evm/plugins/state/bank/interfaces.go
+++ b/cosmos/x/evm/plugins/state/bank/interfaces.go
@@ -1,0 +1,17 @@
+package bank
+
+import (
+	"context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// BankKeeper defines the expected bank keeper.
+type BankKeeper interface {
+	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	SendCoinsFromModuleToAccount(ctx context.Context,
+		senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromAccountToModule(ctx context.Context,
+		senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+	BurnCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+}

--- a/cosmos/x/evm/plugins/state/bank/manager.go
+++ b/cosmos/x/evm/plugins/state/bank/manager.go
@@ -1,0 +1,155 @@
+package bank
+
+import (
+	sdkmath "cosmossdk.io/math"
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"math/big"
+	evmtypes "pkg.berachain.dev/polaris/cosmos/x/evm/types"
+	"pkg.berachain.dev/polaris/eth/common"
+	"pkg.berachain.dev/polaris/lib/ds"
+	"pkg.berachain.dev/polaris/lib/ds/stack"
+)
+
+const (
+	initCapacity    = 16
+	registryKey     = "bank"
+	underlyingDenom = "umito"
+)
+
+type balanceChange struct {
+	Addr  common.Address
+	Delta *big.Int
+}
+
+type state struct {
+	balanceChanges []balanceChange
+	dirtyBalances  map[common.Address]*big.Int
+}
+
+type Manager struct {
+	bankKeeper BankKeeper
+	states     ds.Stack[*state]
+	readOnly   bool
+}
+
+func NewManager(bankKeeper BankKeeper) *Manager {
+	return &Manager{
+		bankKeeper: bankKeeper,
+		states:     stack.New[*state](initCapacity),
+	}
+}
+
+func (m *Manager) getCurState() *state {
+	if m.states.Size() == 0 {
+		m.states.Push(&state{
+			balanceChanges: []balanceChange{},
+			dirtyBalances:  map[common.Address]*big.Int{},
+		})
+	}
+	return m.states.Peek()
+}
+
+func (m *Manager) GetBalance(ctx sdk.Context, addr common.Address) *big.Int {
+	curState := m.getCurState()
+	balance := curState.dirtyBalances[addr]
+	if balance != nil {
+		return balance
+	} else {
+		return m.bankKeeper.GetBalance(ctx, addr.Bytes(), underlyingDenom).Amount.BigInt()
+	}
+}
+
+func (m *Manager) SetBalance(ctx sdk.Context, addr common.Address, newBalance *big.Int) {
+	oldBalance := m.GetBalance(ctx, addr)
+	delta := new(big.Int).Sub(newBalance, oldBalance)
+	if delta.Sign() == 0 {
+		return
+	}
+
+	curState := m.getCurState()
+	curState.balanceChanges = append(curState.balanceChanges, balanceChange{
+		Addr:  addr,
+		Delta: delta,
+	})
+	curState.dirtyBalances[addr] = newBalance
+}
+
+// RegistryKey implements `types.Registrable`.
+func (m *Manager) RegistryKey() string {
+	return registryKey
+}
+
+// Snapshot implements `types.Snapshottable`.
+func (m *Manager) Snapshot() int {
+	curState := m.getCurState()
+	newState := state{
+		balanceChanges: []balanceChange{},
+		dirtyBalances:  map[common.Address]*big.Int{},
+	}
+	for addr, balance := range curState.dirtyBalances {
+		newState.dirtyBalances[addr] = balance
+	}
+
+	return m.states.Push(&newState) - 1
+}
+
+// RevertToSnapshot implements `types.Snapshottable`.
+func (m *Manager) RevertToSnapshot(id int) {
+	m.states.PopToSize(id)
+}
+
+// Finalize implements `types.Finalizeable`.
+func (m *Manager) Finalize() {}
+
+// Commit commits pending changes to bank module.
+func (m *Manager) Commit(ctx sdk.Context) error {
+	// TODO(thai): must consider about error happening in the middle of this function.
+
+	totalDirtyBalances := m.getCurState().dirtyBalances
+	for addr := range totalDirtyBalances {
+		bankBalance := m.bankKeeper.GetBalance(ctx, addr.Bytes(), underlyingDenom)
+		ctx.Logger().Info(fmt.Sprintf("[evm->bank] BEFORE: %s: %s", addr.String(), bankBalance.String()))
+	}
+
+	count := 0
+	for i := 0; i < m.states.Size(); i++ {
+		s := m.states.PeekAt(i)
+
+		for j, change := range s.balanceChanges {
+			switch change.Delta.Sign() {
+			case 1:
+				amount := sdk.NewCoins(sdk.NewCoin(underlyingDenom, sdkmath.NewIntFromBigInt(change.Delta)))
+				if err := m.bankKeeper.MintCoins(ctx, evmtypes.ModuleName, amount); err != nil {
+					return err
+				}
+				if err := m.bankKeeper.SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, change.Addr.Bytes(), amount); err != nil {
+					return err
+				}
+				break
+
+			case -1:
+				amount := sdk.NewCoins(sdk.NewCoin(underlyingDenom, sdkmath.NewIntFromBigInt(new(big.Int).Neg(change.Delta))))
+				if err := m.bankKeeper.SendCoinsFromAccountToModule(ctx, change.Addr.Bytes(), evmtypes.ModuleName, amount); err != nil {
+					return err
+				}
+				if err := m.bankKeeper.BurnCoins(ctx, evmtypes.ModuleName, amount); err != nil {
+					return err
+				}
+				break
+
+			default:
+			}
+
+			count++
+			ctx.Logger().Info(fmt.Sprintf("[evm->bank] CHANGE(#%d)(%d,%d): %s: %s", count, i, j, change.Addr.String(), change.Delta.String()))
+		}
+	}
+
+	for addr := range totalDirtyBalances {
+		bankBalance := m.bankKeeper.GetBalance(ctx, addr.Bytes(), underlyingDenom)
+		ctx.Logger().Info(fmt.Sprintf("[evm->bank] AFTER: %s: %s", addr.String(), bankBalance.String()))
+	}
+
+	return nil
+}

--- a/cosmos/x/evm/plugins/state/genesis.go
+++ b/cosmos/x/evm/plugins/state/genesis.go
@@ -39,7 +39,10 @@ func (p *plugin) InitGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 		// TODO: technically wrong since its overriding / hacking the auth keeper and
 		// we are using the nonce from the account keeper as well.
 		p.CreateAccount(address)
-		p.SetBalance(address, account.Balance)
+
+		// TODO(thai): we should rethink about this since we are using bank module for balances.
+		// p.SetBalance(address, account.Balance)
+
 		if account.Code != nil {
 			p.SetCode(address, account.Code)
 		}
@@ -60,21 +63,22 @@ func (p *plugin) ExportGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 	p.Reset(ctx)
 	ethGen.Alloc = make(core.GenesisAlloc)
 
-	// Iterate Balances and set the genesis accounts.
-	p.IterateBalances(func(address common.Address, balance *big.Int) bool {
-		account, ok := ethGen.Alloc[address]
-		if !ok {
-			account = core.GenesisAccount{}
-		}
-		account.Code = p.GetCode(address)
-		if account.Code != nil {
-			account.Storage = make(map[common.Hash]common.Hash)
-		}
-		account.Balance = p.GetBalance(address)
-		account.Nonce = p.GetNonce(address)
-		ethGen.Alloc[address] = account
-		return false
-	})
+	// NOTE: we use bank module for balances, so we don't need to iterate balances to set the genesis accounts.
+	//// Iterate Balances and set the genesis accounts.
+	//p.IterateBalances(func(address common.Address, balance *big.Int) bool {
+	//	account, ok := ethGen.Alloc[address]
+	//	if !ok {
+	//		account = core.GenesisAccount{}
+	//	}
+	//	account.Code = p.GetCode(address)
+	//	if account.Code != nil {
+	//		account.Storage = make(map[common.Hash]common.Hash)
+	//	}
+	//	account.Balance = p.GetBalance(address)
+	//	account.Nonce = p.GetNonce(address)
+	//	ethGen.Alloc[address] = account
+	//	return false
+	//})
 
 	// Iterate Storage and set the genesis accounts.
 	p.IterateState(func(address common.Address, key common.Hash, value common.Hash) bool {

--- a/cosmos/x/evm/plugins/state/interfaces.go
+++ b/cosmos/x/evm/plugins/state/interfaces.go
@@ -72,3 +72,14 @@ type AccountKeeper interface {
 	RemoveAccount(ctx context.Context, account sdk.AccountI)
 	IterateAccounts(ctx context.Context, cb func(account sdk.AccountI) bool)
 }
+
+// BankKeeper defines the expected bank keeper.
+type BankKeeper interface {
+	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	SendCoinsFromModuleToAccount(ctx context.Context,
+		senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromAccountToModule(ctx context.Context,
+		senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+	BurnCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+}

--- a/cosmos/x/evm/plugins/state/keys.go
+++ b/cosmos/x/evm/plugins/state/keys.go
@@ -27,12 +27,12 @@ import (
 
 // NOTE: we use copy to build keys for max performance: https://github.com/golang/go/issues/55905
 
-func BalanceKeyFor(address common.Address) []byte {
-	bz := make([]byte, 1+common.AddressLength)
-	copy(bz, []byte{types.BalanceKeyPrefix})
-	copy(bz[1:], address[:])
-	return bz
-}
+//func BalanceKeyFor(address common.Address) []byte {
+//	bz := make([]byte, 1+common.AddressLength)
+//	copy(bz, []byte{types.BalanceKeyPrefix})
+//	copy(bz[1:], address[:])
+//	return bz
+//}
 
 // StorageKeyFor returns a prefix to iterate over a given account storage (multiple slots).
 func StorageKeyFor(address common.Address) []byte {

--- a/cosmos/x/evm/plugins/state/plugin.go
+++ b/cosmos/x/evm/plugins/state/plugin.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"pkg.berachain.dev/polaris/cosmos/x/evm/plugins/state/bank"
 	"sync"
 
 	storetypes "cosmossdk.io/store/types"
@@ -58,8 +59,6 @@ type Plugin interface {
 	core.StatePlugin
 	// SetQueryContextFn sets the query context func for the plugin.
 	SetQueryContextFn(fn func(height int64, prove bool) (sdk.Context, error))
-	// IterateBalances iterates over the balances of all accounts and calls the given callback function.
-	IterateBalances(fn func(common.Address, *big.Int) bool)
 	// IterateState iterates over the state of all accounts and calls the given callback function.
 	IterateState(fn func(addr common.Address, key common.Hash, value common.Hash) bool)
 	// SetGasConfig sets the gas config for the plugin.
@@ -106,6 +105,9 @@ type plugin struct {
 	// keepers used for balance and account information.
 	ak AccountKeeper
 
+	bk BankKeeper
+	bm *bank.Manager
+
 	// getQueryContext allows for querying state a historical height.
 	getQueryContext func(height int64, prove bool) (sdk.Context, error)
 
@@ -119,14 +121,27 @@ type plugin struct {
 // NewPlugin returns a plugin with the given context and keepers.
 func NewPlugin(
 	ak AccountKeeper,
+	bk BankKeeper,
 	storeKey storetypes.StoreKey,
 	plf events.PrecompileLogFactory,
 ) Plugin {
 	return &plugin{
 		storeKey: storeKey,
 		ak:       ak,
+		bk:       bk,
 		plf:      plf,
 		mu:       sync.Mutex{},
+	}
+}
+
+// CommitToBank commits pending changes to bank module.
+func (p *plugin) CommitToBank() {
+	if p.bm != nil {
+		err := p.bm.Commit(p.ctx)
+		if err != nil {
+			p.ctx.Logger().Error("failed to commit pending changes to bank module", "err", err)
+			p.savedErr = err
+		}
 	}
 }
 
@@ -167,10 +182,13 @@ func (p *plugin) Reset(ctx context.Context) {
 	// in the EVM are not being charged additional gas unknowingly.
 	p.SetGasConfig(storetypes.GasConfig{}, storetypes.GasConfig{})
 
+	p.bm = bank.NewManager(p.bk)
+
 	// We setup a snapshot controller to properly revert the Controllable MultiStore and EventManager.
 	p.Controller = snapshot.NewController[string, libtypes.Controllable[string]]()
 	_ = p.Controller.Register(p.cms)
 	_ = p.Controller.Register(cem)
+	_ = p.Controller.Register(p.bm)
 
 	// We reset the saved error, so that we can check for errors in the next state transition.
 	p.savedErr = nil
@@ -255,12 +273,14 @@ func (p *plugin) DeleteAccounts(accounts []common.Address) {
 
 // GetBalance implements `StatePlugin` interface.
 func (p *plugin) GetBalance(addr common.Address) *big.Int {
-	return new(big.Int).SetBytes(p.ctx.KVStore(p.storeKey).Get(BalanceKeyFor(addr)))
+	return p.bm.GetBalance(p.ctx, addr)
+	//return new(big.Int).SetBytes(p.ctx.KVStore(p.storeKey).Get(BalanceKeyFor(addr)))
 }
 
 // SetBalance implements `StatePlugin` interface.
 func (p *plugin) SetBalance(addr common.Address, amount *big.Int) {
-	p.ctx.KVStore(p.storeKey).Set(BalanceKeyFor(addr), amount.Bytes())
+	//p.ctx.KVStore(p.storeKey).Set(BalanceKeyFor(addr), amount.Bytes())
+	p.bm.SetBalance(p.ctx, addr, amount)
 }
 
 // AddBalance implements the `StatePlugin` interface by adding the given amount
@@ -492,25 +512,6 @@ func getStateFromStore(
 	return common.Hash{}
 }
 
-func (p *plugin) IterateBalances(fn func(common.Address, *big.Int) bool) {
-	it := storetypes.KVStorePrefixIterator(
-		p.cms.GetKVStore(p.storeKey),
-		[]byte{types.BalanceKeyPrefix},
-	)
-	defer func() {
-		if err := it.Close(); err != nil {
-			p.savedErr = err
-		}
-	}()
-
-	for ; it.Valid(); it.Next() {
-		addr := AddressFromBalanceKey(it.Key())
-		if fn(addr, p.GetBalance(addr)) {
-			break
-		}
-	}
-}
-
 // =============================================================================
 // Historical State
 // =============================================================================
@@ -534,6 +535,7 @@ func (p *plugin) StateAtBlockNumber(number uint64) (core.StatePlugin, error) {
 	// Investigate and hopefully remove this GTE.
 	if int64Number >= p.ctx.BlockHeight() {
 		ctx, _ = p.ctx.CacheContext()
+		// TODO(thai): consider about cloning the bank manager
 	} else {
 		// Get the query context at the given height.
 		var err error
@@ -544,7 +546,7 @@ func (p *plugin) StateAtBlockNumber(number uint64) (core.StatePlugin, error) {
 	}
 
 	// Create a State Plugin with the requested chain height.
-	sp := NewPlugin(p.ak, p.storeKey, p.plf)
+	sp := NewPlugin(p.ak, p.bk, p.storeKey, p.plf)
 	sp.Reset(ctx)
 	return sp, nil
 }
@@ -555,8 +557,9 @@ func (p *plugin) StateAtBlockNumber(number uint64) (core.StatePlugin, error) {
 
 // Clone implements libtypes.Cloneable.
 func (p *plugin) Clone() ethstate.Plugin {
-	sp := NewPlugin(p.ak, p.storeKey, p.plf)
+	sp := NewPlugin(p.ak, p.bk, p.storeKey, p.plf)
 	cacheCtx, _ := p.ctx.CacheContext()
+	// TODO(thai): consider about cloning the bank manager
 	sp.Reset(cacheCtx)
 	return sp
 }

--- a/cosmos/x/evm/types/keys.go
+++ b/cosmos/x/evm/types/keys.go
@@ -21,8 +21,8 @@
 package types
 
 const (
-	CodeKeyPrefix byte = iota
-	BalanceKeyPrefix
+	CodeKeyPrefix    byte = iota
+	BalanceKeyPrefix      // NOTE: should be not used
 	StorageKeyPrefix
 	CodeHashKeyPrefix
 	BlockHashKeyToNumPrefix

--- a/eth/core/mock/state_plugin.mock.go
+++ b/eth/core/mock/state_plugin.mock.go
@@ -28,6 +28,9 @@ var _ core.StatePlugin = &StatePluginMock{}
 //			CloneFunc: func() state.Plugin {
 //				panic("mock out the Clone method")
 //			},
+//			CommitToBankFunc: func()  {
+//				panic("mock out the CommitToBank method")
+//			},
 //			CreateAccountFunc: func(address common.Address)  {
 //				panic("mock out the CreateAccount method")
 //			},
@@ -119,6 +122,9 @@ type StatePluginMock struct {
 	// CloneFunc mocks the Clone method.
 	CloneFunc func() state.Plugin
 
+	// CommitToBankFunc mocks the CommitToBank method.
+	CommitToBankFunc func()
+
 	// CreateAccountFunc mocks the CreateAccount method.
 	CreateAccountFunc func(address common.Address)
 
@@ -208,6 +214,9 @@ type StatePluginMock struct {
 		}
 		// Clone holds details about calls to the Clone method.
 		Clone []struct {
+		}
+		// CommitToBank holds details about calls to the CommitToBank method.
+		CommitToBank []struct {
 		}
 		// CreateAccount holds details about calls to the CreateAccount method.
 		CreateAccount []struct {
@@ -352,6 +361,7 @@ type StatePluginMock struct {
 	}
 	lockAddBalance         sync.RWMutex
 	lockClone              sync.RWMutex
+	lockCommitToBank       sync.RWMutex
 	lockCreateAccount      sync.RWMutex
 	lockDeleteAccounts     sync.RWMutex
 	lockEmpty              sync.RWMutex
@@ -440,6 +450,33 @@ func (mock *StatePluginMock) CloneCalls() []struct {
 	mock.lockClone.RLock()
 	calls = mock.calls.Clone
 	mock.lockClone.RUnlock()
+	return calls
+}
+
+// CommitToBank calls CommitToBankFunc.
+func (mock *StatePluginMock) CommitToBank() {
+	if mock.CommitToBankFunc == nil {
+		panic("StatePluginMock.CommitToBankFunc: method is nil but StatePlugin.CommitToBank was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockCommitToBank.Lock()
+	mock.calls.CommitToBank = append(mock.calls.CommitToBank, callInfo)
+	mock.lockCommitToBank.Unlock()
+	mock.CommitToBankFunc()
+}
+
+// CommitToBankCalls gets all the calls that were made to CommitToBank.
+// Check the length with:
+//
+//	len(mockedStatePlugin.CommitToBankCalls())
+func (mock *StatePluginMock) CommitToBankCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockCommitToBank.RLock()
+	calls = mock.calls.CommitToBank
+	mock.lockCommitToBank.RUnlock()
 	return calls
 }
 

--- a/eth/core/state/interfaces.go
+++ b/eth/core/state/interfaces.go
@@ -87,4 +87,7 @@ type Plugin interface {
 	// ForEachStorage iterates over the storage of an account and calls the given callback
 	// function.
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
+
+	// CommitToBank commits pending changes to bank module.
+	CommitToBank()
 }

--- a/eth/core/state/journal/logs.go
+++ b/eth/core/state/journal/logs.go
@@ -128,7 +128,9 @@ func (l *logs) RevertToSnapshot(id int) {
 // Finalize clears the journal of the tx logs.
 //
 // Finalize implements `libtypes.Controllable`.
-func (l *logs) Finalize() {}
+func (l *logs) Finalize() {
+	// TODO(thai): should be fixed
+}
 
 // Clone implements `libtypes.Cloneable`.
 func (l *logs) Clone() Log {

--- a/eth/core/state/mock/state.mock.go
+++ b/eth/core/state/mock/state.mock.go
@@ -23,6 +23,9 @@ import (
 //			CloneFunc: func() state.Plugin {
 //				panic("mock out the Clone method")
 //			},
+//			CommitToBankFunc: func()  {
+//				panic("mock out the CommitToBank method")
+//			},
 //			CreateAccountFunc: func(address common.Address)  {
 //				panic("mock out the CreateAccount method")
 //			},
@@ -111,6 +114,9 @@ type PluginMock struct {
 	// CloneFunc mocks the Clone method.
 	CloneFunc func() state.Plugin
 
+	// CommitToBankFunc mocks the CommitToBank method.
+	CommitToBankFunc func()
+
 	// CreateAccountFunc mocks the CreateAccount method.
 	CreateAccountFunc func(address common.Address)
 
@@ -197,6 +203,9 @@ type PluginMock struct {
 		}
 		// Clone holds details about calls to the Clone method.
 		Clone []struct {
+		}
+		// CommitToBank holds details about calls to the CommitToBank method.
+		CommitToBank []struct {
 		}
 		// CreateAccount holds details about calls to the CreateAccount method.
 		CreateAccount []struct {
@@ -336,6 +345,7 @@ type PluginMock struct {
 	}
 	lockAddBalance        sync.RWMutex
 	lockClone             sync.RWMutex
+	lockCommitToBank      sync.RWMutex
 	lockCreateAccount     sync.RWMutex
 	lockDeleteAccounts    sync.RWMutex
 	lockEmpty             sync.RWMutex
@@ -423,6 +433,33 @@ func (mock *PluginMock) CloneCalls() []struct {
 	mock.lockClone.RLock()
 	calls = mock.calls.Clone
 	mock.lockClone.RUnlock()
+	return calls
+}
+
+// CommitToBank calls CommitToBankFunc.
+func (mock *PluginMock) CommitToBank() {
+	if mock.CommitToBankFunc == nil {
+		panic("PluginMock.CommitToBankFunc: method is nil but Plugin.CommitToBank was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockCommitToBank.Lock()
+	mock.calls.CommitToBank = append(mock.calls.CommitToBank, callInfo)
+	mock.lockCommitToBank.Unlock()
+	mock.CommitToBankFunc()
+}
+
+// CommitToBankCalls gets all the calls that were made to CommitToBank.
+// Check the length with:
+//
+//	len(mockedPlugin.CommitToBankCalls())
+func (mock *PluginMock) CommitToBankCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockCommitToBank.RLock()
+	calls = mock.calls.CommitToBank
+	mock.lockCommitToBank.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
I customized polaris to sync evm balance and cosmos bank. (a.k.a. "mito <-> umito integration")
It breaks test codes, but I didn't modify test codes because I want to minimize the changes and LoC of PR.

There are some TODOs but I'll have some time to revisit the details later.
And I found some bugs in polaris in the progress of this task. Some of them seem to be fixed in the latest version.