### PR TITLE
feat: implement "reserved account" for temporary purpose

### DIFF
--- a/cosmos/x/evm/plugins/state/genesis.go
+++ b/cosmos/x/evm/plugins/state/genesis.go
@@ -22,10 +22,9 @@ package state
 
 import (
 	"math/big"
+	"pkg.berachain.dev/polaris/eth/core"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/ethereum/go-ethereum/core"
 
 	"pkg.berachain.dev/polaris/eth/common"
 )
@@ -33,6 +32,8 @@ import (
 // InitGenesis takes in a pointer to a genesis state object and populates the KV store.
 func (p *plugin) InitGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 	p.Reset(ctx)
+
+	p.CreateAccount(core.ReservedAddress)
 
 	// Iterate over the genesis accounts and set the balances.
 	for address, account := range ethGen.Alloc {

--- a/cosmos/x/evm/types/tx.go
+++ b/cosmos/x/evm/types/tx.go
@@ -149,6 +149,7 @@ func GetAsEthTx(tx sdk.Tx) *coretypes.Transaction {
 	if !ok {
 		return nil
 	}
+	etr.GetSigners()
 	return etr.AsTransaction()
 }
 

--- a/eth/core/chain_writer.go
+++ b/eth/core/chain_writer.go
@@ -22,9 +22,9 @@ package core
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum/consensus/misc"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/vm"
 
 	"pkg.berachain.dev/polaris/eth/core/types"
@@ -37,7 +37,7 @@ type ChainWriter interface {
 	Prepare(context.Context, uint64)
 	// ProcessTransaction processes the given transaction and returns the receipt after applying
 	// the state transition. This method is called for each tx in the block.
-	ProcessTransaction(context.Context, *types.Transaction) (*ExecutionResult, error)
+	ProcessTransaction(context.Context, *types.Transaction, bool) (*ExecutionResult, error)
 	// Finalize is called after the last tx in the block.
 	Finalize(context.Context) error
 	// SendTx sends the given transaction to the tx pool.
@@ -93,14 +93,14 @@ func (bc *blockchain) Prepare(ctx context.Context, number uint64) {
 }
 
 // ProcessTransaction processes the given transaction and returns the receipt.
-func (bc *blockchain) ProcessTransaction(ctx context.Context, tx *types.Transaction) (*ExecutionResult, error) {
+func (bc *blockchain) ProcessTransaction(ctx context.Context, tx *types.Transaction, isReservedSender bool) (*ExecutionResult, error) {
 	bc.logger.Debug("processing evm transaction", "tx_hash", tx.Hash())
 
 	// Reset the Gas and State plugins for the tx.
 	bc.gp.Reset(ctx) // TODO: may not need this.
 	bc.sp.Reset(ctx)
 
-	return bc.processor.ProcessTransaction(ctx, tx)
+	return bc.processor.ProcessTransaction(ctx, tx, isReservedSender)
 }
 
 // Finalize finalizes the current block.

--- a/eth/core/constants.go
+++ b/eth/core/constants.go
@@ -1,0 +1,11 @@
+package core
+
+import (
+	"pkg.berachain.dev/polaris/eth/common"
+	"pkg.berachain.dev/polaris/eth/crypto"
+)
+
+var (
+	ReservedPrivateKey = crypto.ToECDSAUnsafe(common.FromHex("1234123412341234123412341234123412341234123412341234123412341234"))
+	ReservedAddress    = common.HexToAddress("0xfF06ad5d076fa274B49C297f3fE9e29B5bA9AaDC")
+)

--- a/eth/crypto/imported.go
+++ b/eth/crypto/imported.go
@@ -44,6 +44,7 @@ var (
 	PubkeyToAddress         = crypto.PubkeyToAddress
 	SignatureLength         = crypto.SignatureLength
 	ToECDSA                 = crypto.ToECDSA
+	ToECDSAUnsafe           = crypto.ToECDSAUnsafe
 	VerifySignature         = crypto.VerifySignature
 	FromECDSAPub            = crypto.FromECDSAPub
 )

--- a/eth/polar/mining.go
+++ b/eth/polar/mining.go
@@ -34,8 +34,8 @@ func (pl *Polaris) Prepare(ctx context.Context, number uint64) {
 }
 
 // ProcessTransaction processes the given transaction and returns the receipt.
-func (pl *Polaris) ProcessTransaction(ctx context.Context, tx *types.Transaction) (*core.ExecutionResult, error) {
-	return pl.blockchain.ProcessTransaction(ctx, tx)
+func (pl *Polaris) ProcessTransaction(ctx context.Context, tx *types.Transaction, isReservedSender bool) (*core.ExecutionResult, error) {
+	return pl.blockchain.ProcessTransaction(ctx, tx, isReservedSender)
 }
 
 // Finalize finalizes the current block.


### PR DESCRIPTION
New Concept) Reserved Account
* private key: `1234123412341234123412341234123412341234123412341234123412341234`
* public address: `0xfF06ad5d076fa274B49C297f3fE9e29B5bA9AaDC`

When making an evm call using specific method, reserved private key is used.
And exceptionally gas fee is not charged to reserved account.
It will fail if an external user tries to insert tx into the blockchain using the reserved private key.

It is a temporary and tricky way to resolve existing issues. It will be revisited later.